### PR TITLE
Fix yaml frontmatter & prevent prettier from running

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+draft-parecki-oauth-client-id-metadata-document.md

--- a/draft-parecki-oauth-client-id-metadata-document.md
+++ b/draft-parecki-oauth-client-id-metadata-document.md
@@ -12,7 +12,7 @@ v: 3
 area: "Security"
 workgroup: "Web Authorization Protocol"
 keyword:
- - oauth
+  - oauth
 venue:
   group: "Web Authorization Protocol"
   type: "Working Group"
@@ -21,13 +21,11 @@ venue:
   latest: "https://aaronpk.github.io/draft-parecki-oauth-client-id-metadata-document/draft-parecki-oauth-client-id-metadata-document.html"
 
 author:
- -
-    fullname: Aaron Parecki
+  - fullname: Aaron Parecki
     organization: Okta
     email: aaron@parecki.com
-    url: https://aaronparecki.com
- -
-    fullname: Emelia Smith
+    uri: https://aaronparecki.com
+  - fullname: Emelia Smith
     email: emelia@brandedcode.com
 
 normative:


### PR DESCRIPTION
Was starting to work on the draft, and was having compiling errors due to the yaml frontmatter having been incorrectly formatted by prettier (it really chokes on it), and the `url` property should've been `uri` from what I can tell.