### PR TITLE
Suggested improvements

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+draft-parecki-oauth-client-id-metadata-document.md

--- a/draft-parecki-oauth-client-id-metadata-document.md
+++ b/draft-parecki-oauth-client-id-metadata-document.md
@@ -27,6 +27,7 @@ author:
     uri: https://aaronparecki.com
   - fullname: Emelia Smith
     email: emelia@brandedcode.com
+    uri: https://thisismissem.social
 
 normative:
   RFC3986:
@@ -36,7 +37,19 @@ normative:
   I-D.draft-ietf-oauth-security-topics:
 
 informative:
-
+  IndieAuth:
+    title: "IndieAuth"
+    target: https://indieauth.spec.indieweb.org/
+  Solid-OIDC:
+    title: "Solid-OIDC"
+    date: 2022-03-28
+    target: https://solidproject.org/TR/2022/oidc-20220328
+    author:
+      - name: Aaron Coburn
+        org: Inrupt
+      - name: elf Pavlik
+        ins: elf Pavlik
+      - name: Dmitri Zagidulin
 
 --- abstract
 
@@ -196,4 +209,6 @@ This document has no IANA actions.
 # Acknowledgments
 {:numbered="false"}
 
-TODO acknowledge.
+The idea of using URIs as the `client_id` in OAuth based authorization requests is not new, and has previously been specified in varying ways by [IndieAuth] and [Solid-OIDC]. This specification is largely inspired by the work of Aaron Coburn, elf Pavlik, and Dmitri Zagidulin in their [Solid-OIDC] specification which defined dereferenceable Client Identifier Documents.
+
+TODO further acknowledgements?

--- a/draft-parecki-oauth-client-id-metadata-document.md
+++ b/draft-parecki-oauth-client-id-metadata-document.md
@@ -123,7 +123,7 @@ defined in [RFC3986] Section 6.2.1.
 
 The client metadata document MAY define additional properties in the response.
 The client metadata document MAY also be served with more specific content types
-as long as the response is JSON and conforms to application/<AS-defined>+json.
+as long as the response is JSON and conforms to `application/<AS-defined>+json`.
 
 Other specifications MAY place additional restrictions on the contents of the
 client metadata document accepted by authorization servers implementing their

--- a/draft-parecki-oauth-client-id-metadata-document.md
+++ b/draft-parecki-oauth-client-id-metadata-document.md
@@ -29,6 +29,7 @@ author:
     email: emelia@brandedcode.com
 
 normative:
+  RFC3986:
   RFC6749:
   RFC6819:
   RFC7591:
@@ -39,25 +40,29 @@ informative:
 
 --- abstract
 
-This specification defines an endpoint an OAuth client can use to host its client metadata, as well as the use of this URL as a `client_id` in an OAuth flow. This enables OAuth clients to work with authorization servers where it has no prior relationship, and enables the authorization server to fetch metadata about the client.
-
+This specification defines a mechanism through which an OAuth client can
+identify itself to authorization servers, without prior dynamic client
+registration or other existing registration. This is through the usage of a URL
+as a `client_id` in an OAuth flow, where the URL refers to a document containing
+the necessary client metadata, enabling the authorization server to fetch the
+metadata about the client as needed.
 
 --- middle
 
 # Introduction
 
 In order for an OAuth 2.0 {{RFC6749}} client to utilize an OAuth 2.0
-authorization server, the client needs to establish a unique
-identifier, and needs to to provide the server with metadata about
-the application, such as the application name and icon.  In cases
-where a client is interacting with authorization servers that it has
-no relationship with, manual registration is impossible.
+authorization server, the client needs to establish a unique identifier, and
+needs to to provide the server with metadata about the application, such as the
+application name, icon and redirect URIs. In cases where a client is interacting
+with authorization servers that it has no relationship with, manual registration
+is impossible.
 
-While Dynamic Client Registration {{RFC7591}} can provide a method for a previously
-unknown client to establish itself at an authorization server and
-obtain a client idenfier, this is not always practical in some deployments
-and can create additional challenges around management of the registration
-data and cleanup of inactive clients.
+While Dynamic Client Registration {{RFC7591}} can provide a method for a
+previously unknown client to establish itself at an authorization server and
+obtain a client identifier, this is not always practical in some deployments and
+can create additional challenges around management of the registration data and
+cleanup of inactive clients.
 
 This specification describes how an OAuth 2.0 client can publish its
 own registration information and avoid the need for pre-registering
@@ -67,28 +72,27 @@ at each authorization server.
 
 {::boilerplate bcp14-tagged}
 
-
 # Client Identifier
 
-This specification defines the client identifier as a URL with
-the following restrictions. Client identifier URLs MUST have
-an "https" scheme, MUST contain a path component, MUST NOT
-contain single-dot or double-dot path segments, MAY contain a query
-string component, MUST NOT contain a fragment component, MUST NOT
-contain a username or password component, and MAY contain a port.
+This specification defines the client identifier as a URL with the following
+restrictions. Client identifier URLs MUST have an "https" scheme, MUST contain a
+path component, MUST NOT contain single-dot or double-dot path segments, MUST
+NOT contain a fragment component and MUST NOT contain a username or password
+component. Client identifier URLs MAY contain a query string component and MAY
+contain a port.
 
 This specification places no restrictions on what URL is used as
 a client identifier. A short URL is RECOMMENDED, since the URL may
 be displayed to the end user in the authorization interface or in
-management interfaces.
-
+management interfaces. Usage of a stable URL that does not frequently
+change for the client is also RECOMMENDED.
 
 # Client Information Discovery
 
 One purpose of registering clients at the authorization server is so that
-the authorziation server has additional information about the client that
+the authorization server has additional information about the client that
 can be used during an OAuth flow, such as presenting information about
-the client to the user in an authorziation consent screen, for example the
+the client to the user in an authorization consent screen, for example the
 client name and logo.
 
 The authorization server SHOULD fetch the document indicated by the `client_id`
@@ -100,12 +104,37 @@ The client metadata document URL is a JSON document containing the metadata
 of the client. The client metadata values are the values defined in
 OAuth Dynamic Client Registration ({{RFC7591}}) section 2.
 
+The client metadata document MUST contain a `client_id` property whose value
+MUST compare and match the URL of the document using simple string comparison as
+defined in [RFC3986] Section 6.2.1.
+
+The client metadata document MAY define additional properties in the response.
+The client metadata document MAY also be served with more specific content types
+as long as the response is JSON and conforms to application/<AS-defined>+json.
+
+Other specifications MAY place additional restrictions on the contents of the
+client metadata document accepted by authorization servers implementing their
+specification, for instance, preventing the registration of confidential clients
+by requiring the `token_endpoint_auth_method` property be set to `"none"`.
 
 ## Metadata Discovery Errors
 
-If fetching the metadata document fails, the authorization server MAY abort the
-authorization request, or continue with the information it has available.
+If fetching the metadata document fails, the authorization server SHOULD abort the
+authorization request.
 
+## Metadata Caching
+
+The authorization server MAY cache the client metadata it discovers at the
+client metadata document URL.
+
+TBD: recommend a cache lifetime? considerations about stale data?
+
+The authorization server MUST NOT cache error responses. The authorization
+server also MUST NOT cache documents which are invalid or malformed.
+
+TBD: Do we want to define an endpoint through which a document can be validated
+by an authorization server, such that a developer can assert that their document
+is valid?
 
 ## Redirect URL Registration
 
@@ -116,13 +145,7 @@ registered redirect URL with the authorization server which is used when
 comparing the redirect URL in an authorization request against the registered
 redirect URLs.
 
-
-## Metadata Caching
-
-The authorization server MAY cache the client information it discovers at the
-metadata document URL.
-
-TBD: recommend a cache lifetime? considerations about stale data?
+TBD: Is it exact string matching, or is it still using simple string comparison per [RFC3986]
 
 
 # Security Considerations
@@ -151,11 +174,11 @@ the authorization server MUST include client authentication of the registered ty
 
 ## OAuth Phishing Attacks
 
-Authorization servers SHOULD fetch the `client_id` metadata document provided in the authorization request in order to provide users with additional information about the request, such as the application name and logo. If the server does not fetch the client information, then it SHOULD take additional measures to ensure the user is provided with as much information as possible about the request.
+Authorization servers SHOULD fetch the `client_id` metadata document provided in the authorization request in order to provide users with additional information about the request, such as the application name and logo. If the server does not fetch the client metadata document, then it SHOULD take additional measures to ensure the user is provided with as much information as possible about the request.
 
 The authorization server SHOULD display the hostname of the `client_id` on the authorization interface, in addition to displaying the fetched client information if any. Displaying the hostname helps users know that they are authorizing the expected application.
 
-If fetching the client metadata fails for any reason, the `client_id` URL is the only piece of information the user has as an indication of which application they are authorizing.
+If fetching the client metadata document fails for any reason, the `client_id` URL is the only piece of information the user has as an indication of which application they are authorizing.
 
 
 ## Server Side Request Forgery (SSRF) Attacks

--- a/draft-parecki-oauth-client-id-metadata-document.md
+++ b/draft-parecki-oauth-client-id-metadata-document.md
@@ -12,7 +12,7 @@ v: 3
 area: "Security"
 workgroup: "Web Authorization Protocol"
 keyword:
- - oauth
+  - oauth
 venue:
   group: "Web Authorization Protocol"
   type: "Working Group"
@@ -21,13 +21,11 @@ venue:
   latest: "https://aaronpk.github.io/draft-parecki-oauth-client-id-metadata-document/draft-parecki-oauth-client-id-metadata-document.html"
 
 author:
- -
-    fullname: Aaron Parecki
+  - fullname: Aaron Parecki
     organization: Okta
     email: aaron@parecki.com
-    url: https://aaronparecki.com
- -
-    fullname: Emelia Smith
+    uri: https://aaronparecki.com
+  - fullname: Emelia Smith
     email: emelia@brandedcode.com
 
 normative:


### PR DESCRIPTION
This is based on #1, but otherwise has a few language and spelling changes; Additionally:
- added the section about the restriction on the `client_id` property strictly matching the client metadata document's URI
- added recommendation to use a stable URL (I'm not sure if there's a spec to refer to, but it'd be bad practice to, for example, include a version number in the URL for cache busting purposes even though the contents of the document has not actually changed.
- added TBD about possible verification endpoint (i.e., giving developers an easy way to verify their document is valid (or perhaps a mechanism to invalidate a previously cached document?)
- added language to allow extensions to the client metadata document, and allowing it to be served as content types other than just `application/json`, e.g., `application/ld+json`
- moved caching up to beneath errors, as to allow language to easily flow about requirements not to cache error responses or invalid documents.
- added TBD question on the redirect URI matching and whether it is exact string matching or simple string comparison (the original language).
- tried to use `client metadata document` more consistently.