### PR TITLE
Add Accept header requirement when fetching Client Metadata

### DIFF
--- a/draft-parecki-oauth-client-id-metadata-document.md
+++ b/draft-parecki-oauth-client-id-metadata-document.md
@@ -151,7 +151,8 @@ the client to the user in an authorization consent screen, for example the
 client name and logo.
 
 The authorization server SHOULD fetch the document indicated by the `client_id`
-to retrieve the client registration information.
+to retrieve the client registration information. The Authorization Server MUST
+send an `Accept` header of `application/json` when fetching the client metadata.
 
 ## Client Metadata
 


### PR DESCRIPTION
This was noted in https://github.com/aaronpk/draft-parecki-oauth-client-id-metadata-document/issues/30#issuecomment-3081686148

This pull request will conflict with #46

Is there any RFC we should specifically reference here with regards to the Accept header?